### PR TITLE
fix: missing bracket

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -219,7 +219,7 @@ runs:
          options(crayon.enabled = TRUE, timeout=Sys.getenv("timeout"))
          ## For running the checks
          message(paste('****', Sys.time(), 'installing rcmdcheck ****')) 
-         install.packages(c("rmarkdown","BiocManager", dependencies = TRUE, repos = repos)
+         install.packages(c("rmarkdown","BiocManager", dependencies = TRUE, repos = repos))
          
          ## Speedup installation with AnVIL 
          repos <- if(


### PR DESCRIPTION
A bracket was missing in the `Install dependencies pass 1` chunk, leading to [this error](https://github.com/neurogenomics/rworkflows/actions/runs/4863237498/jobs/8670667662#step:4:824). 