### PR TITLE
Switch to automatically set up GITHUB_TOKEN

### DIFF
--- a/R/use_workflow.R
+++ b/R/use_workflow.R
@@ -45,6 +45,8 @@
 #' rendering Sweave (.rnw) and other documentation files.
 #' @param github_token Token for the repo. 
 #' Can be passed in using {{ secrets.PAT_GITHUB }}.
+#' By default, it uses {{ secrets.GITHUB_TOKEN }}
+#' automatically set up. 
 #' @param docker_user DockerHub username.
 #' @param docker_org DockerHub organization name. 
 #' Is the same as \code{docker_user} by default.
@@ -92,7 +94,7 @@ use_workflow <- function(## action-level args
                          has_runit=FALSE, 
                          has_latex=FALSE,
                          run_docker=FALSE,  
-                         github_token="${{ secrets.PAT_GITHUB }}",
+                         github_token="${{ secrets.GITHUB_TOKEN }}",
                          docker_user=NULL,
                          docker_org=docker_user,
                          docker_token="${{ secrets.DOCKER_TOKEN }}",

--- a/README.Rmd
+++ b/README.Rmd
@@ -94,7 +94,7 @@ Step-by-step tutorial showing how to use `rworkflows` in an R package.
 Before pushing changes to your new R package, you will need to set up one or more
 [GitHub Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets):
 
-* `PAT_GITHUB` [Required]: Speeds up installations and gives access to private
+* `PAT_GITHUB` [Optional]: Can grant access to private
     repos on GitHub Actions. You can generate your very own Personal
     Authentication Token with `usethis::create_github_token()`. See the [GitHub docs](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) for details.   
 * `DOCKER_TOKEN` [Optional]: Allows GitHub Actions to push to a

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Before pushing changes to your new R package, you will need to set up
 one or more [GitHub
 Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets):
 
-- `PAT_GITHUB` \[Required\]: Speeds up installations and gives access to
+- `PAT_GITHUB` \[Optional\]: Can grant access to
   private repos on GitHub Actions. You can generate your very own
   Personal Authentication Token with `usethis::create_github_token()`.
   See the [GitHub

--- a/action.yml
+++ b/action.yml
@@ -85,6 +85,7 @@ runs:
   steps:
     - name: Set GitHub environment variables 
       run: |
+        echo "GITHUB_PAT=${{ inputs.GITHUB_TOKEN }}" >> $GITHUB_ENV
         echo "GITHUB_TOKEN=${{ inputs.GITHUB_TOKEN }}" >> $GITHUB_ENV
         echo "RGL_USE_NULL=TRUE" >> $GITHUB_ENV
         echo "R_REMOTES_NO_ERRORS_FROM_WARNINGS=${{ true }}" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,9 @@ inputs:
       GitHub authentication token with permissions to push 
       to the R package's GitHub repository. 
       Also used to bypass GitHub download limits.
-      Can be passed in using {{ secrets.PAT_GITHUB }}.
+      Automatically set to {{ secrets.GITHUB_TOKEN }} by 
+      default, but can be changed to allow access to
+      specific scopes.
   cache_version: 
     description: >
       Which cache version to use. 
@@ -83,7 +85,6 @@ runs:
   steps:
     - name: Set GitHub environment variables 
       run: |
-        echo "GITHUB_PAT=${{ inputs.GITHUB_TOKEN }}" >> $GITHUB_ENV
         echo "GITHUB_TOKEN=${{ inputs.GITHUB_TOKEN }}" >> $GITHUB_ENV
         echo "RGL_USE_NULL=TRUE" >> $GITHUB_ENV
         echo "R_REMOTES_NO_ERRORS_FROM_WARNINGS=${{ true }}" >> $GITHUB_ENV

--- a/inst/example/check_rworkflows-merged.yml
+++ b/inst/example/check_rworkflows-merged.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   check_rworkflows-merged:
+    permissinos: 
+      contents: write
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
     container: ${{ matrix.config.cont }}
@@ -33,7 +35,7 @@ jobs:
           run_covr: true
           run_pkgdown: true
           has_runit: false 
-          GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
           run_docker: true
           docker_user: 'bschilder'
           docker_org: 'neurogenomicslab'

--- a/inst/example/rworkflows.yml
+++ b/inst/example/rworkflows.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test-document-deploy:
+    permissions: 
+      contents: write
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
     container: ${{ matrix.config.cont }}
@@ -27,7 +29,7 @@ jobs:
           run_covr: true
           run_pkgdown: true
           has_runit: false 
-          GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
           run_docker: true
           docker_user: 'bschilder'
           docker_org: 'neurogenomicslab'

--- a/inst/templates/rworkflows_template.yml
+++ b/inst/templates/rworkflows_template.yml
@@ -7,6 +7,8 @@
     branches: [main, master, 'RELEASE_**']
 'jobs':
   rworkflows:
+    permissions:
+      contents: write
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
     container: ${{ matrix.config.cont }}
@@ -37,7 +39,7 @@
           run_pkgdown: true
           has_runit: false
           has_latex: false
-          GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
           run_docker: true
           docker_user: 'bschilder'
           docker_org: 'neurogenomicslab'

--- a/inst/templates/rworkflows_template_static.yml
+++ b/inst/templates/rworkflows_template_static.yml
@@ -3,6 +3,8 @@ on:
 env:
 jobs:
   rworkflows_static:
+    permissions: 
+      contents: write
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
     container: ${{ matrix.config.cont }} 

--- a/man/use_workflow.Rd
+++ b/man/use_workflow.Rd
@@ -27,7 +27,7 @@ use_workflow(
   has_runit = FALSE,
   has_latex = FALSE,
   run_docker = FALSE,
-  github_token = "${{ secrets.PAT_GITHUB }}",
+  github_token = "${{ secrets.GITHUB_TOKEN }}",
   docker_user = NULL,
   docker_org = docker_user,
   docker_token = "${{ secrets.DOCKER_TOKEN }}",
@@ -98,7 +98,9 @@ rendering Sweave (.rnw) and other documentation files.}
 \item{run_docker}{Whether to build and push a Docker container to DockerHub.}
 
 \item{github_token}{Token for the repo. 
-Can be passed in using {{ secrets.PAT_GITHUB }}.}
+Can be passed in using {{ secrets.PAT_GITHUB }}.
+By default, it uses {{ secrets.GITHUB_TOKEN }}
+automatically set up.}
 
 \item{docker_user}{DockerHub username.}
 

--- a/vignettes/rworkflows.Rmd
+++ b/vignettes/rworkflows.Rmd
@@ -23,10 +23,10 @@ library(`r pkg`)
 
 # GitHub Secrets 
 
-Before pushing changes to your new R package, you will need to set up one or more
+Before pushing changes to your new R package, you may want to set up one or more
 [GitHub Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets):
 
-* `PAT_GITHUB` [Required]: Speeds up installations and gives access to private
+* `PAT_GITHUB` [Optional]: Can grant access to private
     repos on GitHub Actions. You can generate your very own Personal
     Authentication Token using [these
     instructions](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).   


### PR DESCRIPTION
Currently the `rworkflows.yml` **requires** a specific "PAT_GITHUB" secret to be set up in each repo using the GHA. 
However, GitHub automatically sets up `{{ secrets.GITHUB_TOKEN }}` for any GHA job, without needing to set it up manually, so this could be used instead of a manually set up "PAT_GITHUB". 

This requires adding `permissions` set for `contents: write` for any job relying on `{{ secrets.GITHUB_TOKEN }}`, otherwise JamesIves deploy GHA won't work (see here: https://github.com/JamesIves/github-pages-deploy-action#:~:text=If%20you%20do,permissions%20it%20needs.)

More here: https://docs.github.com/en/actions/security-guides/automatic-token-authentication