### PR TITLE
Install quarto >= 1.5 to allow rendering qmd vignettes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -366,10 +366,10 @@ runs:
         install.packages("pkgdown")
       shell: Rscript {0}
 
-    - name: 🛠 Install gh cli
+    - name: 🛠 Install gh cli and jq
       if: inputs.run_pkgdown == 'true' && runner.os == 'Linux'
       run: |
-        sudo apt-get install -y gh
+        sudo apt-get install -y gh jq
       shell: bash {0}
 
     - name: 🛠 Update quarto to latest release

--- a/action.yml
+++ b/action.yml
@@ -366,6 +366,10 @@ runs:
         install.packages("pkgdown")
       shell: Rscript {0}
 
+    - name: 🛠 Install quarto 
+      if: inputs.run_pkgdown == 'true' && runner.os == 'Linux'
+      uses: quarto-dev/quarto-actions/setup@v2
+
     - name: ℹ️ Session info ️
       run: |
         options(width = 100, crayon.enabled = TRUE)

--- a/action.yml
+++ b/action.yml
@@ -366,9 +366,17 @@ runs:
         install.packages("pkgdown")
       shell: Rscript {0}
 
-    - name: 🛠 Install quarto 
+    - name: 🛠 Install gh cli
+      if: inputs.run_pkgdown == 'true' && runner.os == 'Linux'
+      run: |
+        sudo apt-get install -y gh
+      shell: bash {0}
+
+    - name: 🛠 Update quarto to latest release
       if: inputs.run_pkgdown == 'true' && runner.os == 'Linux'
       uses: quarto-dev/quarto-actions/setup@v2
+      with:
+        version: release
 
     - name: ℹ️ Session info ️
       run: |


### PR DESCRIPTION
Just to let you know: `pkgdown` has recently switched to `quarto` to build websites. This enables to render qmd vignettes. I've added 3 steps to your action, to install `gh`, `jq`, and eventually update `quarto` to latest version (quarto shipped in Bioconductor Docker images is < 1.5). This should be sufficient to build qmd vignettes!

https://www.tidyverse.org/blog/2024/07/pkgdown-2-1-0/#quarto-support