### PR TITLE
Add support for CODECOV_TOKEN

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -330,7 +330,7 @@ runs:
          install.packages(c("rmarkdown","BiocManager"), dependencies = TRUE)
          message(paste('****', Sys.time(), 'pass number 1 at installing dependencies****'))
          repos <- BiocManager::repositories()
-         remotes::install_local(repos=repos, dependencies=TRUE, build_vignettes=FALSE, upgrade=TRUE, force=FALSE)
+         remotes::install_local(repos=repos, dependencies=TRUE, build_vignettes=FALSE, upgrade=TRUE, force=TRUE)
       continue-on-error: true
       shell: Rscript {0}
 
@@ -342,7 +342,7 @@ runs:
         options(crayon.enabled = TRUE, timeout=Sys.getenv("timeout"))
         message(paste('****', Sys.time(), 'pass number 2 at installing dependencies****'))
         repos <- BiocManager::repositories()
-        remotes::install_local(repos=repos, dependencies=TRUE, build_vignettes=FALSE, upgrade=TRUE, force=FALSE)
+        remotes::install_local(repos=repos, dependencies=TRUE, build_vignettes=FALSE, upgrade=TRUE, force=TRUE)
       shell: Rscript {0}
 
     - name: 🛠 Install RUnit (via BiocGenerics) 

--- a/action.yml
+++ b/action.yml
@@ -96,6 +96,12 @@ inputs:
       (e.g. {{ secrets.PAT_GITHUB }}) which allows access to private
       repositories. Read here for more details: 
       https://docs.github.com/en/actions/security-guides/automatic-token-authentication.
+  CODECOV_TOKEN:
+    description: >
+      Codecov repository token needed to upload coverage reports. 
+      Providing this token helps prevent report upload failures by bypassing
+      Codecov's GitHub API rate limits. Read here for more details:
+      https://docs.codecov.com/docs/adding-the-codecov-token
   cache_version: 
     description: >
       Which cache version to use. 
@@ -330,7 +336,7 @@ runs:
          install.packages(c("rmarkdown","BiocManager"), dependencies = TRUE)
          message(paste('****', Sys.time(), 'pass number 1 at installing dependencies****'))
          repos <- BiocManager::repositories()
-         remotes::install_local(repos=repos, dependencies=TRUE, build_vignettes=FALSE, upgrade=TRUE, force=TRUE)
+         remotes::install_local(repos=repos, dependencies=TRUE, build_vignettes=FALSE, upgrade=TRUE, force=FALSE)
       continue-on-error: true
       shell: Rscript {0}
 
@@ -342,7 +348,7 @@ runs:
         options(crayon.enabled = TRUE, timeout=Sys.getenv("timeout"))
         message(paste('****', Sys.time(), 'pass number 2 at installing dependencies****'))
         repos <- BiocManager::repositories()
-        remotes::install_local(repos=repos, dependencies=TRUE, build_vignettes=FALSE, upgrade=TRUE, force=TRUE)
+        remotes::install_local(repos=repos, dependencies=TRUE, build_vignettes=FALSE, upgrade=TRUE, force=FALSE)
       shell: Rscript {0}
 
     - name: 🛠 Install RUnit (via BiocGenerics) 
@@ -441,9 +447,13 @@ runs:
     
     - name: 📋 Test coverage 
       if: inputs.run_covr == 'true' && runner.os == 'Linux'
+      env: 
+        CODECOV_TOKEN: ${{ inputs.CODECOV_TOKEN }}
       run: |
+        ## NOTE: codecov() uses CODECOV_TOKEN env var if specified.
+        ## (recommended)
         covr::codecov()
-      shell: Rscript {0} 
+      shell: Rscript {0}
       
     - name: 🛠 Install package ️
       if: inputs.run_pkgdown == 'true' && runner.os == 'Linux'


### PR DESCRIPTION
Add support for the `CODECOV_TOKEN` GitHub secret. This input helps prevent coverage report upload failures, which have been quite frequent recently.

Coverage report upload failure error:
```
Run covr::codecov()
  covr::codecov()
  shell: Rscript {0}
  env:
    RGL_USE_NULL: TRUE
    R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
    RSPM: https://packagemanager.rstudio.com/cran/__linux__/focal/release
    TZ: UTC
    NOT_CRAN: false
Request failed [429]. Retrying in 1 seconds...
Request failed [429]. Retrying in 2.5 seconds...
$detail
[1] "Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected time to availability: 1915s."
```

More information: https://docs.codecov.com/docs/adding-the-codecov-token

This implementation has been successfully tested on [`MotifPeeker`](https://github.com/neurogenomics/MotifPeeker) with my fork.