### PR TITLE
Update artifact actions

### DIFF
--- a/.github/workflows/rworkflows_static.yml
+++ b/.github/workflows/rworkflows_static.yml
@@ -358,7 +358,7 @@ jobs:
         token: ${{ env.GITHUB_TOKEN }}
     - name: ⏫ Upload check results
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ runner.os }}-biocversion-${{ matrix.config.bioc }}-r-${{  matrix.config.r
           }}-results

--- a/action.yml
+++ b/action.yml
@@ -557,7 +557,7 @@ runs:
 
     - name: ⏫ Upload check results 
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ runner.os }}-biocversion-${{ matrix.config.bioc }}-r-${{  matrix.config.r }}-results
         path: check 


### PR DESCRIPTION
Hello!


rworkflows uses v3 of the artifact actions, but it is now deprecated which causes our runs to fail.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

-Tuomas